### PR TITLE
Backend Server: Serve Frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # Experimental Hub
 
 An online tool for researchers in the field of synchrony to host and conduct customizable online experiments with users.
+
+**TODO** _features_
+
+# Setup
+
+**TODO**: _pre-build release can be found_ ...
+
+**TODO**: _quick setup / start + requirements_
+
+---
+
+## Building & Starting
+
+For the general setup and prerequisites, please take a look at the [frontend](./frontend/README.md#configuration) and [backend](./backend/README.md#configuration) READMEs.
+
+1. Build frontend
+    - Skip this step if there where no changes to the frontend since the last build process
+    - Go to the frontend directory: `cd frontend`
+    - Build the frontend: `npm run build`. Make sure the build process finishes without any errors
+2. (Re-) Start server
+    - If the server is already running: stop the server
+    - Make sure to take a look at the settings. For more details see [backend README](./backend/README.md#configuration)
+        - It is recommended to set `environment` to `prod` to disable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+    - Start the server by executing `main.py` in the backend directory. For example from the root directory: `python backend/main.py`
+
+### Notes
+
+-   For development, the React / frontend development server is recommended: `npm start`

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# experimental-hub
-An online tool for researchers in the field of synchrony to host and conduct custimizable online experiements with users. 
+# Experimental Hub
+
+An online tool for researchers in the field of synchrony to host and conduct customizable online experiments with users.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ An online tool for researchers in the field of synchrony to host and conduct cus
 
 ## Building & Starting
 
+In case you want to build the frontend yourself, follow the steps in this section.
+
 For the general setup and prerequisites, please take a look at the [frontend](./frontend/README.md#configuration) and [backend](./backend/README.md#configuration) READMEs.
+Continue with the steps bellow after both the frontend and backend are set up.
 
 1. Build frontend
     - Skip this step if there where no changes to the frontend since the last build process
@@ -22,7 +25,7 @@ For the general setup and prerequisites, please take a look at the [frontend](./
     - Build the frontend: `npm run build`. Make sure the build process finishes without any errors
 2. (Re-) Start server
     - If the server is already running: stop the server
-    - Make sure to take a look at the settings. For more details see [backend README](./backend/README.md#configuration)
+    - Make sure to take a look at the settings. For more details see [backend configuration](./backend/README.md#configuration)
         - It is recommended to set `environment` to `prod` to disable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
     - Start the server by executing `main.py` in the backend directory. For example from the root directory: `python backend/main.py`
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -18,7 +18,9 @@ The backend can be configured using the `backend/config.json`.
 -   `host` - str : host address the backend should use
 -   `port` - int : port the backend should use
 -   `environment` - str : `dev` or `prod`
--   `https` - bool : Weather the backend should use https
+-   `serve_frontend` - bool : Whether the server should serve the frontend. Set to `false` if the frontend is hosted by a different server (see note bellow)
+    -   Developer Note: A better way to host the frontend would be using a [Reverse Proxy](https://en.wikipedia.org/wiki/Reverse_proxy) like [nginx](https://nginx.org/) or [CDN](https://en.wikipedia.org/wiki/Content_delivery_network) services, as noted in [aiohttp](https://docs.aiohttp.org/en/stable/web_advanced.html?highlight=static#static-file-handling) which we use for hosting.
+-   `https` - bool : Whether the backend should use https
 -   `ssl_cert` - str : path to ssl certificate. Only used if https is true
 -   `ssl_key` - str : path to ssl private key. Only used if https is true
 -   `log` - str : Logging level for Hub. Must be one of: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`. Default: `INFO`

--- a/backend/config.json
+++ b/backend/config.json
@@ -2,6 +2,7 @@
 	"host": "127.0.0.1",
 	"port": 8080,
 	"environment": "dev",
+	"serve_frontend": true,
 	"log": "DEBUG",
 	"log_file": null,
 	"log_dependencies": "WARNING",

--- a/backend/modules/__init__.py
+++ b/backend/modules/__init__.py
@@ -4,3 +4,7 @@ from pathlib import Path
 
 BACKEND_DIR = Path(__file__).parent.parent
 """Root directory for backend."""
+
+
+FRONTEND_BUILD_DIR = BACKEND_DIR.parent / "frontend/build"
+"""Directory with frontend build."""

--- a/backend/modules/config.py
+++ b/backend/modules/config.py
@@ -14,6 +14,7 @@ class Config:
     host: str
     port: int
     environment: Literal["dev", "prod"]
+    serve_frontend: bool
     https: bool
     ssl_cert: str | None
     ssl_key: str | None
@@ -44,6 +45,7 @@ class Config:
             "host": str,
             "port": int,
             "environment": str,  # Literal not supported here, check afterwards.
+            "serve_frontend": bool,
             "https": bool,
             "log": str,
             "log_dependencies": str,
@@ -76,6 +78,7 @@ class Config:
         self.host = config["host"]
         self.port = config["port"]
         self.environment = config["environment"]
+        self.serve_frontend = config["serve_frontend"]
         self.https = config["https"]
         self.log = config["log"]
         self.log_dependencies = config["log_dependencies"]
@@ -110,11 +113,12 @@ class Config:
         """Get string representation of parameters in this Config."""
         return (
             f"host={self.host}, port={self.port}, environment={self.environment}, "
-            f"https={self.https}, ssl_cert={self.ssl_cert}, ssl_key={self.ssl_key}, "
-            f"log={self.log}, log_dependencies={self.log_dependencies}, log_file="
-            f"{self.log_file}, ping_subprocesses={self.ping_subprocesses},"
-            f"experimenter_multiprocessing={self.experimenter_multiprocessing}, "
-            f"participant_multiprocessing={self.participant_multiprocessing}."
+            f"https={self.https}, serve_frontend={self.serve_frontend}, ssl_cert="
+            f"{self.ssl_cert}, ssl_key={self.ssl_key}, log={self.log}, log_dependencies"
+            f"={self.log_dependencies}, log_file={self.log_file}, ping_subprocesses="
+            f"{self.ping_subprocesses}, experimenter_multiprocessing="
+            f"{self.experimenter_multiprocessing}, participant_multiprocessing="
+            f"{self.participant_multiprocessing}."
         )
 
     def __repr__(self) -> str:

--- a/backend/modules/server.py
+++ b/backend/modules/server.py
@@ -70,7 +70,14 @@ class Server:
         # Serve frontend build
         # Redirect sub-pages to index (client handles routing -> single-page app)
         # Add new pages here!
-        pages = ["/", "/postProcessingRoom", "/sessionForm", "/connectionTest"]
+        pages = [
+            "/",
+            "/postProcessingRoom",
+            "/experimentRoom",
+            "/watchingRoom",
+            "/sessionForm",
+            "/connectionTest",
+        ]
         for page in pages:
             routes.append(self._app.router.add_get(page, self.get_index))
         routes.extend(self._app.add_routes([web.static("/", FRONTEND_BUILD_DIR)]))

--- a/backend/modules/server.py
+++ b/backend/modules/server.py
@@ -69,18 +69,22 @@ class Server:
 
         # Serve frontend build
         # Redirect sub-pages to index (client handles routing -> single-page app)
-        # Add new pages here!
-        pages = [
-            "/",
-            "/postProcessingRoom",
-            "/experimentRoom",
-            "/watchingRoom",
-            "/sessionForm",
-            "/connectionTest",
-        ]
-        for page in pages:
-            routes.append(self._app.router.add_get(page, self.get_index))
-        routes.extend(self._app.add_routes([web.static("/", FRONTEND_BUILD_DIR)]))
+        if self._config.serve_frontend:
+            # Add new pages here!
+            pages = [
+                "/",
+                "/postProcessingRoom",
+                "/experimentRoom",
+                "/watchingRoom",
+                "/sessionForm",
+                "/connectionTest",
+            ]
+            for page in pages:
+                routes.append(self._app.router.add_get(page, self.get_index))
+            routes.extend(self._app.add_routes([web.static("/", FRONTEND_BUILD_DIR)]))
+        else:
+            # If not serving frontend, server hello world on index
+            routes.append(self._app.router.add_get("/", self.get_hello_world))
 
         self._logger.debug(f"Routes: {repr(routes)}")
 

--- a/backend/modules/server.py
+++ b/backend/modules/server.py
@@ -1,5 +1,6 @@
 """Provides the `Server` class, which serves the frontend and other endpoints."""
 
+import asyncio
 import logging
 import aiohttp_cors
 import json
@@ -8,30 +9,32 @@ from aiohttp import web
 from datetime import datetime
 from aiortc import RTCSessionDescription
 from ssl import SSLContext
+from os.path import join
 
 from custom_types.participant_summary import ParticipantSummaryDict
 from custom_types.message import MessageDict
 from custom_types.error import ErrorDict
 
 from modules.exceptions import ErrorDictException
+from modules import FRONTEND_BUILD_DIR
 from modules.config import Config
+
+
+_HANDLER = Callable[
+    [
+        RTCSessionDescription,
+        Literal["participant", "experimenter"],
+        Optional[str],
+        Optional[str],
+    ],
+    Coroutine[Any, Any, tuple[RTCSessionDescription, ParticipantSummaryDict | None]],
+]
 
 
 class Server:
     """Server providing the website and an endpoint to establish WebRTC connections."""
 
-    _HANDLER = Callable[
-        [
-            RTCSessionDescription,
-            Literal["participant", "experimenter"],
-            Optional[str],
-            Optional[str],
-        ],
-        Coroutine[
-            Any, Any, tuple[RTCSessionDescription, ParticipantSummaryDict | None]
-        ],
-    ]
-
+    _index: str
     _logger: logging.Logger
     _hub_handle_offer: _HANDLER
     _app: web.Application
@@ -55,19 +58,31 @@ class Server:
         self._logger = logging.getLogger("Server")
         self._hub_handle_offer = hub_handle_offer
         self._config = config
+        self._index = self._read_index()
 
         self._app = web.Application()
         self._app.on_shutdown.append(self._shutdown)
-        routes = []
-        routes.append(self._app.router.add_get("/", self.get_hello_world))
-        routes.append(self._app.router.add_post("/offer", self.handle_offer))
+        routes = [
+            self._app.router.add_get("/hello-world", self.get_hello_world),
+            self._app.router.add_post("/offer", self.handle_offer),
+        ]
+
+        # Serve frontend build
+        # Redirect sub-pages to index (client handles routing -> single-page app)
+        # Add new pages here!
+        pages = ["/", "/postProcessingRoom", "/sessionForm", "/connectionTest"]
+        for page in pages:
+            routes.append(self._app.router.add_get(page, self.get_index))
+        routes.extend(self._app.add_routes([web.static("/", FRONTEND_BUILD_DIR)]))
+
+        self._logger.debug(f"Routes: {repr(routes)}")
 
         if config.environment != "dev":
             return
 
         # Using cors is only intended for development, when the client is not hosted by
         # this server but a separate development server.
-        self._logger.info("Using CORS. Only use for development!")
+        self._logger.warning("Using CORS. Only use for development!")
 
         cors = aiohttp_cors.setup(self._app)  # type: ignore
         for route in routes:
@@ -271,14 +286,18 @@ class Server:
         answer = MessageDict(type="SESSION_DESCRIPTION", data=data)
         return web.Response(content_type="application/json", text=json.dumps(answer))
 
-    def get_index(self):
-        """TODO document"""
-        pass
+    async def get_index(self, request: web.Request):
+        """Respond with index.html to an request."""
+        self._logger.info(f'Received "{request.path}" request from {request.remote}')
+        return web.Response(content_type="text/html", text=self._index)
 
-    def get_css(self):
-        """TODO document"""
-        pass
+    def _read_index(self) -> str:
+        """Read index.html from `FRONTEND_BUILD_DIR`.
 
-    def get_javascript(self):
-        """TODO document"""
-        pass
+        Notes
+        -----
+        Blocking IO.  Use asyncio's `run_in_executor` to avoid, if desired.
+        """
+        path = join(FRONTEND_BUILD_DIR, "index.html")
+        with open(path, "r") as file:
+            return file.read()

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,6 +1,7 @@
 # Changes to the enviroment require a node restart.
 
 # Backend address 
+# Only used for frontend dev server
 REACT_APP_BACKEND="http://127.0.0.1:8080"
 
 # Optional ICE servers

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.16.3",
         "@testing-library/react": "^12.1.4",
         "eslint-config-react-app": "^7.0.1",
+        "postcss-calc": "^8.2.4",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-icons": "^4.3.1",
@@ -10780,6 +10781,18 @@
         "postcss": ">=8"
       }
     },
+    "node_modules/postcss-calc": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
+      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.9",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.2"
+      }
+    },
     "node_modules/postcss-clamp": {
       "version": "4.1.0",
       "license": "MIT",
@@ -21178,6 +21191,15 @@
     "postcss-browser-comments": {
       "version": "4.0.0",
       "requires": {}
+    },
+    "postcss-calc": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
+      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+      "requires": {
+        "postcss-selector-parser": "^6.0.9",
+        "postcss-value-parser": "^4.2.0"
+      }
     },
     "postcss-clamp": {
       "version": "4.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^12.1.4",
     "eslint-config-react-app": "^7.0.1",
+    "postcss-calc": "^8.2.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-icons": "^4.3.1",

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -43,13 +43,21 @@ export const INITIAL_NOTE_DATA = {
   speakers: [],
   content: "",
 };
-export const BACKEND = process.env.REACT_APP_BACKEND;
 
 /**
  * Environment of the client. Set by CreateReactApp depending on how you start it.
  * @type {("development" | "test" | "production")}
  */
 export const ENVIRONMENT = process.env.NODE_ENV; // "development", "test" or "production"
+
+/**
+ * Backend address.
+ */
+export const BACKEND = (
+  ENVIRONMENT === "production"
+    ? window.location.origin
+    : process.env.REACT_APP_BACKEND
+);
 
 /**
  * Optional ICE servers. 
@@ -72,6 +80,5 @@ function parseIceServers() {
     return undefined;
   }
 }
-console.log("ICE_SERVERS", ICE_SERVERS)
 
 export const PARTICIPANT_HOST = "https://localhost:3000/experimentRoom/";


### PR DESCRIPTION
# Changes

Add ability to serve the frontend to the backend server

## Backend

-   Add steps for building to root README
-   Add `serve_frontend` to backend config
-   Serve frontend, including static files, in Server

# Frontend

-   Add missing package: `postcss-calc` (solves _missing_ error when building without)
- Update `BACKEND` variable in constants.js to use the current url as backend address in production (build)