### PR TITLE
created speaking time filter

### DIFF
--- a/backend/filters/__init__.py
+++ b/backend/filters/__init__.py
@@ -10,6 +10,7 @@ from .rotate import RotationFilter
 from .mute import MuteAudioFilter, MuteVideoFilter
 from .delay import DelayFilter
 from .open_face_au import OpenFaceAUFilter
+from .speaking_time import DisplaySpeakingTimeFilter, AudioSpeakingTimeFilter
 
 # Do not import filters after here
 from . import filter_factory

--- a/backend/filters/speaking_time/__init__.py
+++ b/backend/filters/speaking_time/__init__.py
@@ -1,0 +1,2 @@
+from .audio_speaking_time_filter import AudioSpeakingTimeFilter
+from .display_speaking_time_filter import DisplaySpeakingTimeFilter

--- a/backend/filters/speaking_time/audio_speaking_time_filter.py
+++ b/backend/filters/speaking_time/audio_speaking_time_filter.py
@@ -1,0 +1,31 @@
+import time
+
+import numpy
+from av import AudioFrame
+from filters.filter_dict import FilterDict
+
+from filters.filter import Filter
+
+
+class AudioSpeakingTimeFilter(Filter):
+    """Filter calculating how much time the participant has spoken"""
+
+    seconds: float
+    _config: FilterDict
+
+    def __init__(
+        self, config: FilterDict, audio_track_handler, video_track_handler
+    ) -> None:
+        super().__init__(config, audio_track_handler, video_track_handler)
+        self.seconds = float(0)
+
+    @staticmethod
+    def name(self) -> str:
+        return "AUDIO_SPEAKING_TIME"
+
+    async def process(
+        self, audioFrame: AudioFrame, ndarray: numpy.ndarray
+    ) -> numpy.ndarray:
+        if numpy.abs(ndarray).mean() > 125:
+            self.seconds += audioFrame.samples / audioFrame.sample_rate
+        return ndarray

--- a/backend/filters/speaking_time/audio_speaking_time_filter.py
+++ b/backend/filters/speaking_time/audio_speaking_time_filter.py
@@ -1,5 +1,3 @@
-import time
-
 import numpy
 from av import AudioFrame
 from filters.filter_dict import FilterDict

--- a/backend/filters/speaking_time/display_speaking_time_filter.py
+++ b/backend/filters/speaking_time/display_speaking_time_filter.py
@@ -1,0 +1,54 @@
+from typing import TypeGuard
+
+import cv2
+import numpy
+from .audio_speaking_time_filter import AudioSpeakingTimeFilter
+from av import VideoFrame
+
+from custom_types import util
+from filters.filter import Filter
+from .display_speaking_time_filter_dict import DisplaySpeakingTimeFilterDict
+
+
+class DisplaySpeakingTimeFilter(Filter):
+    _config: DisplaySpeakingTimeFilterDict
+    _speaking_time_filter: AudioSpeakingTimeFilter
+
+    async def complete_setup(self) -> None:
+        speaking_time_filter_id = self._config["audio_speaking_time_filter_id"]
+        speaking_time_filter = self.audio_track_handler.filters[speaking_time_filter_id]
+        self._speaking_time_filter = speaking_time_filter  # type: ignore
+
+    @staticmethod
+    def name(self) -> str:
+        return "DISPLAY_SPEAKING_TIME"
+
+    async def process(
+        self, original: VideoFrame, ndarray: numpy.ndarray
+    ) -> numpy.ndarray:
+        height, _, _ = ndarray.shape
+        origin = (10, height - 10)
+        font = cv2.FONT_HERSHEY_SIMPLEX
+        font_size = 1
+        thickness = 3
+        color = (0, 255, 0)
+        """
+        if self._speaking_time_filter.has_spoken:
+            self._speaking_time_filter.speaking_time += self._speaking_time_filter.sample_rate // original.pts
+            self._speaking_time_filter.seconds = self._speaking_time_filter.speaking_time // self._speaking_time_filter.sample_rate
+        """
+        text = str(self._speaking_time_filter.seconds)
+
+        # Put text on image
+        ndarray = cv2.putText(ndarray, text, origin, font, font_size, color, thickness)
+
+        # Return modified frame
+        return ndarray
+
+    @staticmethod
+    def validate_dict(data) -> TypeGuard[DisplaySpeakingTimeFilterDict]:
+        return (
+            util.check_valid_typeddict_keys(data, DisplaySpeakingTimeFilterDict)
+            and "audio_speaking_time_filter_id" in data
+            and isinstance(data["audio_speaking_time_filter_id"], str)
+        )

--- a/backend/filters/speaking_time/display_speaking_time_filter_dict.py
+++ b/backend/filters/speaking_time/display_speaking_time_filter_dict.py
@@ -1,0 +1,17 @@
+from filters.filter_dict import FilterDict
+
+
+class DisplaySpeakingTimeFilterDict(FilterDict):
+    """TypedDict for name filter.
+
+    Attributes
+    ----------
+    type : str
+        filter type (unique identifier / name)
+    id : str
+        Filter id.  Empty string if adding a new filter.  Read only for client.
+    audio_speaking_time_filter_id : str
+        Id for the audio speaking time filter
+    """
+
+    audio_speaking_time_filter_id: str

--- a/frontend/src/pages/ConnectionTest/ConnectionTest.tsx
+++ b/frontend/src/pages/ConnectionTest/ConnectionTest.tsx
@@ -566,6 +566,46 @@ function SetFilterPresets(props: { connection: Connection }): JSX.Element {
         >
           60 Frame audio + video Delay
         </button>
+        <button
+          onClick={() =>
+            props.connection.sendMessage("SET_FILTERS", {
+              participant_id: "all",
+              video_filters: [],
+              audio_filters: [
+                {
+                  type: "AUDIO_SPEAKING_TIME",
+                  id: "audio-speaking-time"
+                }
+              ]
+            })
+          }
+          disabled={props.connection.state !== ConnectionState.CONNECTED}
+        >
+          Speaking Time
+        </button>
+        <button
+          onClick={() =>
+            props.connection.sendMessage("SET_FILTERS", {
+              participant_id: "all",
+              audio_filters: [
+                {
+                  type: "AUDIO_SPEAKING_TIME",
+                  id: "audio-speaking-time"
+                }
+              ],
+              video_filters: [
+                {
+                  type: "DISPLAY_SPEAKING_TIME",
+                  id: "display-speaking-time",
+                  audio_speaking_time_filter_id: "audio-speaking-time"
+                }
+              ]
+            })
+          }
+          disabled={props.connection.state !== ConnectionState.CONNECTED}
+        >
+          Display Speaking Time
+        </button>
       </div>
     </>
   );


### PR DESCRIPTION
This PR fixes Issue #71 

- I have created a filter to measure the speaking time of a participant, i.e., how many seconds a participants talks.
- It measures the absolute mean value of the audio input (the volume received) and compares it to a threshold (which I assigned to 125)
- Please try out the new filter in the ConnectionTest Page (under display speaking time). It should count the seconds someone talks. As is determined the threshold to a fixed number, the accuracy of the filter is not nearly at 100% and heavenly depends on the ambient noise and the quality of your microphone.
