### PR TITLE
Reset creation time back to 0

### DIFF
--- a/frontend/src/redux/slices/openSessionSlice.ts
+++ b/frontend/src/redux/slices/openSessionSlice.ts
@@ -72,6 +72,7 @@ export const openSessionSlice = createSlice({
       state.session = {
         ...payload,
         id: "",
+        creation_time: 0,
         participants: payload.participants.map((p) => ({
           ...p,
           id: ""


### PR DESCRIPTION
### Fixes session duplication issue for experiments with "ongoing" state

