### PR TITLE
Filter configuration key change & Save session with default empty group filters

### DIFF
--- a/backend/experiment/experiment.py
+++ b/backend/experiment/experiment.py
@@ -443,8 +443,8 @@ class Experiment(AsyncIOEventEmitter):
             # Reuse existing filter for matching id and type.
             if (
                 filter_id in old_group_filter_aggregators
-                and old_group_filter_aggregators[filter_id]._group_filter.config["type"]
-                == config["type"]
+                and old_group_filter_aggregators[filter_id]._group_filter.config["name"]
+                == config["name"]
             ):
                 self._video_group_filter_aggregators[
                     filter_id
@@ -492,8 +492,8 @@ class Experiment(AsyncIOEventEmitter):
             # Reuse existing filter for matching id and type.
             if (
                 filter_id in old_group_filter_aggregators
-                and old_group_filter_aggregators[filter_id]._group_filter.config["type"]
-                == config["type"]
+                and old_group_filter_aggregators[filter_id]._group_filter.config["name"]
+                == config["name"]
             ):
                 self._audio_group_filter_aggregators[
                     filter_id

--- a/backend/experiment/experiment.py
+++ b/backend/experiment/experiment.py
@@ -440,7 +440,7 @@ class Experiment(AsyncIOEventEmitter):
         coroutines = []
         for config, port in zip(group_filter_configs, ports):
             filter_id = config["id"]
-            # Reuse existing filter for matching id and type.
+            # Reuse existing filter for matching id and name.
             if (
                 filter_id in old_group_filter_aggregators
                 and old_group_filter_aggregators[filter_id]._group_filter.config["name"]
@@ -489,7 +489,7 @@ class Experiment(AsyncIOEventEmitter):
         coroutines = []
         for config, port in zip(group_filter_configs, ports):
             filter_id = config["id"]
-            # Reuse existing filter for matching id and type.
+            # Reuse existing filter for matching id and name.
             if (
                 filter_id in old_group_filter_aggregators
                 and old_group_filter_aggregators[filter_id]._group_filter.config["name"]

--- a/backend/filters/filter_utils.py
+++ b/backend/filters/filter_utils.py
@@ -27,7 +27,7 @@ def is_valid_filter_dict(data) -> TypeGuard[FilterDict]:
         True if `data` is a valid FilterDict.
     """
     if "name" not in data:
-        logger.debug("Missing key: type")
+        logger.debug("Missing key: name")
         return False
 
     filter_name = data["name"]

--- a/backend/group_filters/group_filter.py
+++ b/backend/group_filters/group_filter.py
@@ -38,7 +38,7 @@ class GroupFilter(ABC):
         Parameters
         ----------
         config : custom_types.filter.FilterDict
-            Configuration for filter.  `config["type"]` must match the filter
+            Configuration for filter.  `config["name"]` must match the filter
             implementation.
 
         Notes
@@ -49,7 +49,7 @@ class GroupFilter(ABC):
         filters after __init__ (if they are designed to be).
         """
         self._logger = logging.getLogger(
-            f"{config['type']}-GroupFilter-P-{participant_id}"
+            f"{config['name']}-GroupFilter-P-{participant_id}"
         )
         self._config = config
         self.participant_id = participant_id

--- a/backend/group_filters/group_filter_aggregator_factory.py
+++ b/backend/group_filters/group_filter_aggregator_factory.py
@@ -10,15 +10,15 @@ from hub.exceptions import ErrorDictException
 def create_group_filter_aggregator(
     channel: str, group_filter_config: FilterDict, port: int
 ) -> GroupFilterAggregator:
-    group_filter_type = group_filter_config["type"]
+    group_filter_name = group_filter_config["name"]
 
     group_filters = group_filter_utils.get_group_filter_dict()
 
-    if group_filter_type not in group_filters:
+    if group_filter_name not in group_filters:
         raise ErrorDictException(
             code=404,
             type="UNKNOWN_FILTER_TYPE",
-            description=f"Unknown group filter type {group_filter_type}.",
+            description=f"Unknown group filter type {group_filter_name}.",
         )
 
-    return GroupFilterAggregator(channel, group_filters[group_filter_type], port)
+    return GroupFilterAggregator(channel, group_filters[group_filter_name], port)

--- a/backend/group_filters/group_filter_factory.py
+++ b/backend/group_filters/group_filter_factory.py
@@ -9,15 +9,15 @@ from hub.exceptions import ErrorDictException
 def create_group_filter(
     group_filter_config: FilterDict, participant_id: str
 ) -> GroupFilter:
-    group_filter_type = group_filter_config["type"]
+    group_filter_name = group_filter_config["name"]
 
     group_filters = group_filter_utils.get_group_filter_dict()
 
-    if group_filter_type not in group_filters:
+    if group_filter_name not in group_filters:
         raise ErrorDictException(
             code=404,
             type="UNKNOWN_FILTER_TYPE",
-            description=f"Unknown group filter type {group_filter_type}.",
+            description=f"Unknown group filter type {group_filter_name}.",
         )
 
-    return group_filters[group_filter_type](group_filter_config, participant_id)
+    return group_filters[group_filter_name](group_filter_config, participant_id)

--- a/backend/group_filters/group_filter_utils.py
+++ b/backend/group_filters/group_filter_utils.py
@@ -13,24 +13,24 @@ logger = logging.getLogger("GroupFilters")
 
 
 def is_valid_filter_dict(data) -> TypeGuard[FilterDict]:
-    if "type" not in data:
-        logger.debug("Missing key: type")
+    if "name" not in data:
+        logger.debug("Missing key: name")
         return False
 
-    group_filter_type = data["type"]
+    group_filter_name = data["name"]
 
-    if not isinstance(group_filter_type, str):
-        logger.debug('GroupFilter "type" must be of type str.')
+    if not isinstance(group_filter_name, str):
+        logger.debug('GroupFilter "name" must be of type str.')
         return False
 
     group_filters = get_group_filter_dict()
 
-    if group_filter_type not in group_filters:
-        logging.debug(f"Invalid filter type: {group_filter_type}.")
+    if group_filter_name not in group_filters:
+        logging.debug(f"Invalid filter type: {group_filter_name}.")
         return False
 
     return isinstance(data["id"], str) and group_filters[
-        group_filter_type
+        group_filter_name
     ].validate_dict(data)
 
 

--- a/backend/hub/track_handler.py
+++ b/backend/hub/track_handler.py
@@ -289,7 +289,7 @@ class TrackHandler(MediaStreamTrack):
             # Reuse existing filter for matching id and type.
             if (
                 filter_id in old_group_filters
-                and old_group_filters[filter_id].config["type"] == config["type"]
+                and old_group_filters[filter_id].config["name"] == config["name"]
             ):
                 self._group_filters[filter_id] = old_group_filters[filter_id]
                 self._group_filters[filter_id].set_config(config)

--- a/frontend/src/pages/ConnectionTest/ConnectionTest.tsx
+++ b/frontend/src/pages/ConnectionTest/ConnectionTest.tsx
@@ -767,7 +767,15 @@ function SetFilterPresets(props: { connection: Connection }): JSX.Element {
           onClick={() =>
             props.connection.sendMessage("SET_GROUP_FILTERS", {
               audio_group_filters: [],
-              video_group_filters: [{ type: "TEMPLATE_GF", id: "template_gf" }]
+              video_group_filters: [
+                {
+                  name: "TEMPLATE_GF",
+                  id: "template_gf",
+                  channel: "video",
+                  groupFilter: true,
+                  config: {}
+                }
+              ]
             })
           }
           disabled={props.connection.state !== ConnectionState.CONNECTED}

--- a/frontend/src/pages/SessionForm/SessionForm.js
+++ b/frontend/src/pages/SessionForm/SessionForm.js
@@ -189,6 +189,8 @@ function SessionForm({ onSendSessionToBackend }) {
           banned: false,
           audio_filters: [],
           video_filters: [],
+          audio_group_filters: [],
+          video_group_filters: [],
           chat: [],
           position: {
             x: 10,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -33,6 +33,8 @@ export type Participant = {
   chat: ChatMessage[];
   audio_filters: Filter[];
   video_filters: Filter[];
+  audio_group_filters: Filter[];
+  video_group_filters: Filter[];
 };
 
 export type Box = {

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -34,6 +34,8 @@ export const INITIAL_PARTICIPANT_DATA: Participant = {
   banned: false,
   video_filters: [],
   audio_filters: [],
+  audio_group_filters: [],
+  video_group_filters: [],
   chat: [],
   position: {
     x: 10,


### PR DESCRIPTION
This is a PR to solve a bug in save-session use case with group filters.
- By default no group filters are applied for new sessions and the support for adding group filters along with dynamic filters is not yet implemented. This PR is only for hotfix to create sessions with no group filters.
- FilterDict configuration keys are updated based on the dynamic filter support but full support for dynamic filters is not yet implemented.

