### PR TITLE
Fix for duplicating a session

### DIFF
--- a/frontend/src/redux/slices/openSessionSlice.ts
+++ b/frontend/src/redux/slices/openSessionSlice.ts
@@ -73,6 +73,8 @@ export const openSessionSlice = createSlice({
         ...payload,
         id: "",
         creation_time: 0,
+        end_time: 0,
+        start_time: 0,
         participants: payload.participants.map((p) => ({
           ...p,
           id: ""

--- a/frontend/src/redux/slices/openSessionSlice.ts
+++ b/frontend/src/redux/slices/openSessionSlice.ts
@@ -75,9 +75,12 @@ export const openSessionSlice = createSlice({
         creation_time: 0,
         end_time: 0,
         start_time: 0,
+        notes: [],
+        log: [],
         participants: payload.participants.map((p) => ({
           ...p,
-          id: ""
+          id: "",
+          chat: []
         }))
       };
     }


### PR DESCRIPTION
set end and start time to 0 when duplicating a session

Test:
- start and end an experiment
- duplicate the experiment