### PR TITLE
Raw video recording & discard black frames

### DIFF
--- a/backend/connection/connection.py
+++ b/backend/connection/connection.py
@@ -70,6 +70,7 @@ class Connection(ConnectionInterface):
     _tasks: list[asyncio.Task]
     _audio_record_handler: RecordHandler
     _video_record_handler: RecordHandler
+    _raw_video_record_handler: RecordHandler
 
     def __init__(
         self,
@@ -121,7 +122,14 @@ class Connection(ConnectionInterface):
         self._video_record_handler = RecordHandler(
             self._incoming_video, record, record_to
         )
+        # Since experimenter's path recording is empty, so we try to avoid adding raw so experimenter will not be recorded
+        if (record_to != ""):
+            record_to += "_raw"
 
+        self._raw_video_record_handler = RecordHandler(
+            self._incoming_video, record, record_to
+        )
+        
         self._dc = None
         self._tasks = []
 
@@ -274,13 +282,13 @@ class Connection(ConnectionInterface):
     async def start_recording(self) -> None:
         # For docstring see ConnectionInterface or hover over function declaration
         await asyncio.gather(
-            self._video_record_handler.start(), self._audio_record_handler.start()
+            self._video_record_handler.start(), self._raw_video_record_handler.start(), self._audio_record_handler.start()
         )
 
     async def stop_recording(self) -> None:
         # For docstring see ConnectionInterface or hover over function declaration
         await asyncio.gather(
-            self._video_record_handler.stop(), self._audio_record_handler.stop()
+            self._video_record_handler.stop(), self._raw_video_record_handler.stop(), self._audio_record_handler.stop()
         )
 
     async def set_video_filters(self, filters: list[FilterDict]) -> None:
@@ -432,6 +440,7 @@ class Connection(ConnectionInterface):
             task = asyncio.create_task(self._incoming_video.set_track(track))
             sender = self._main_pc.addTrack(self._incoming_video.subscribe())
             self._video_record_handler.add_track(self._incoming_video.subscribe())
+            self._raw_video_record_handler.add_track(track)
             self._listen_to_track_close(self._incoming_video, sender)
         else:
             self._logger.error(f"Unknown track kind {track.kind}. Ignoring track")

--- a/backend/hub/record_handler.py
+++ b/backend/hub/record_handler.py
@@ -81,7 +81,7 @@ class RecordHandler:
         """Stop RecordHandler."""
         end_time = time.time()
         duration = end_time - self._start_time
-        self._recorder.stop()
+        await self._recorder.stop()
         self._logger.debug(f"Stop recording {self._record_to}")
 
         if self._track.kind == 'video':

--- a/backend/hub/record_handler.py
+++ b/backend/hub/record_handler.py
@@ -3,14 +3,11 @@
 from __future__ import annotations
 import logging
 import time
-
 from aiortc.contrib.media import MediaRecorder, MediaBlackhole
-from pyee.asyncio import AsyncIOEventEmitter
-
 from hub.track_handler import TrackHandler
 
 
-class RecordHandler():
+class RecordHandler:
     """Handles audio and video recording of the stream."""
 
     _logger: logging.Logger
@@ -44,6 +41,7 @@ class RecordHandler():
         self._track = track
         self._record = record
         self._record_to = record_to
+        self._start_time = 0
 
         if self._track.kind == "audio":
             track_format = "mp3"


### PR DESCRIPTION
# Description

This PR adds a raw video recording of the participant. However, the black screen issue still persists because the video streams are running when the participant is connected to the hub and we don't record it right away, so empty frames are by default turned into black frames or muted frames (for reference: https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/enabled, https://github.com/aiortc/aiortc/issues/264).

There are two approaches that could resolve this:

1. Replace the video stream object that is running before the experiment starts with the new one.  Then, record the new video stream. This one is I think pretty big change because we really need to remove them from the connection first and kind of reconnect them..

2. Calculate the duration of experiment from the experiment starts - it ends / the participant disconnects. Then trim that duration ffrom the last frames of the video, which is a bit hacky but I think quite good 😄

# Result
Audo file is working fine. Trimming process only for video.
| Video Duration (seconds) | Size (MB) | Trimming Time (seconds) |
|--------------------|-----------|-------------------------|
| 67.89              | 4         | 8.07                    |
| 91.7               | 3         | 4.94                    |
| 801.27             | 51.2      | 68.02                   |

# Future improvement
- Show dialog or pop-up after the experiment ended to tell the user that the recording takes some time.
- Investigate proper way to resolve the black frames

This closes issue #36 🙌 