### PR TITLE
Fix bug where fps would halve when recording was started

### DIFF
--- a/backend/connection/connection.py
+++ b/backend/connection/connection.py
@@ -37,6 +37,8 @@ from filter_api import FilterAPIInterface
 from custom_types.message import MessageDict, is_valid_messagedict
 from session.data.participant.participant_summary import ParticipantSummaryDict
 
+from aiortc.contrib.media import MediaRelay
+
 
 class Connection(ConnectionInterface):
     """Connection with a single client using multiple sub-connections.
@@ -492,10 +494,12 @@ class Connection(ConnectionInterface):
             self._audio_record_handler.add_track(self._incoming_audio.subscribe())
             self._listen_to_track_close(self._incoming_audio, sender)
         elif track.kind == "video":
-            task = asyncio.create_task(self._incoming_video.set_track(track))
+            # Use relay to be able to access track multiple times
+            relay = MediaRelay()
+            task = asyncio.create_task(self._incoming_video.set_track(relay.subscribe(track, False)))
             sender = self._main_pc.addTrack(self._incoming_video.subscribe())
             self._video_record_handler.add_track(self._incoming_video.subscribe())
-            self._raw_video_record_handler.add_track(track)
+            self._raw_video_record_handler.add_track(relay.subscribe(track, False))
             self._listen_to_track_close(self._incoming_video, sender)
         else:
             self._logger.error(f"Unknown track kind {track.kind}. Ignoring track")


### PR DESCRIPTION
# Overview
Fix a bug where the fps of the video stream would have when the session was recorded

## Changes
Add media relay, so that filters and record handler can both access the media stream. This is needed when multiple objects want to access a track (see track_handler.py)

## How to test?
Create experiment that is recorded. Join as participant using connection test page. Start experiment. FPS should stay the same.

# Checklist
- [x] Correct base branch was selected (usually `development`)
- [x] `development` was merged into this branch and potential conflicts resolved
- [x] [Issues](https://github.com/TUMFARSynchrony/experimental-hub/issues) which were solved are linked. Be sure to make that manually because Closes/Fixes keywords only work when base branch is main.
- [x] Terminology is consistent with the rest of the codebase
- [x] Reviewers are assigned
- [x] ~~Optional: Wiki pages were updated to reflect the changes (list changed pages above)~~