### PR TITLE
fix: update deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/backend-static-code-analysis.yml
+++ b/.github/workflows/backend-static-code-analysis.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/frontend-workflow.yml
+++ b/.github/workflows/frontend-workflow.yml
@@ -22,15 +22,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             **/node_modules


### PR DESCRIPTION
# Overview
Updated actions to use current versions to resolve Node.js 20 deprecation warnings that causes our build to fail. Claude was used.

## Changes 
edits to .github/workflows .yml files:
- actions/checkout: v2/v3 -> v4
- actions/setup-python: v4 -> v5
- actions/setup-node: v1 -> v4
- actions/cache: v2 -> v4

## How to test?
do the build's succeed? 

# Checklist
- [ ] Correct base branch was selected (usually `development`)
- [ ] `development` was merged into this branch and potential conflicts resolved
- [ ] [Issues](https://github.com/TUMFARSynchrony/experimental-hub/issues) which were solved are linked. Be sure to make that manually because Closes/Fixes keywords only work when base branch is main.
- [ ] Terminology is consistent with the rest of the codebase
- [ ] Reviewers are assigned
- [ ] Optional: Wiki pages were updated to reflect the changes (list changed pages above)