### PR TITLE
Camera Permission of Experimenter Issue #263 (with claude code)

### DIFF
--- a/frontend/src/components/atoms/Video/Video.tsx
+++ b/frontend/src/components/atoms/Video/Video.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from "react";
 import { Image, Group, Text } from "react-konva";
-import { useUserStream } from "./Streams";
 import { Participant } from "../../../types";
 import Konva from "konva";
 
@@ -12,12 +11,12 @@ type VideoProps = {
 };
 
 const Video = ({ src, participantData, title, shouldMute }: VideoProps) => {
-  const useVideo = (stream: MediaStream | null) => {
+  const useVideo = () => {
     const videoRef = useRef(document.createElement("video"));
 
     useEffect(() => {
       const video = videoRef.current;
-      if (!stream) {
+      if (!src) {
         return;
       }
 
@@ -29,13 +28,12 @@ const Video = ({ src, participantData, title, shouldMute }: VideoProps) => {
       video.onloadedmetadata = function () {
         video.play();
       };
-    }, [stream]);
+    }, [src]);
 
     return videoRef.current;
   };
 
-  const stream = useUserStream();
-  const video = useVideo(stream);
+  const video = useVideo();
   const shapeRef: React.MutableRefObject<Konva.Image> = useRef();
 
   useEffect(() => {


### PR DESCRIPTION
fix: remove unnecessary camera/mic permission request for experimenter


# Overview
The Experimenter was getting camera and mic permission request from their browser even though they are not sharing their video or audio streams. 
With claude: the Video component in Video.tsx was calling useUserStream() to get the local stream although just needing the src MediaProvider. This caused the browser to prompt experimenters for camera/microphone access for rendering the Video component despite them not sharing their own video.

## Changes
Replaced the local stream dependency with src in the useEffect, and removed the useUserStream() call and its import entirely.

## How to test?
Join an experiment as an experimenter in different browsers (tested with chrome, firefox, safari, brave - also in incognito mode) and don't have browser permissions pop-up.

# Checklist
- [ ] Correct base branch was selected (usually `development`)
- [ ] `development` was merged into this branch and potential conflicts resolved
- [ ] [Issues](https://github.com/TUMFARSynchrony/experimental-hub/issues) which were solved are linked. Be sure to make that manually because Closes/Fixes keywords only work when base branch is main.
- [ ] Terminology is consistent with the rest of the codebase
- [ ] Reviewers are assigned
- [ ] Optional: Wiki pages were updated to reflect the changes (list changed pages above)